### PR TITLE
[BER-428] Korrigiert URL für das Validieren in der Kundenangaben-API

### DIFF
--- a/EUROPACE API Calls.postman_collection.json
+++ b/EUROPACE API Calls.postman_collection.json
@@ -39,7 +39,7 @@
 								}
 							}
 						},
-						"url": "https://baufinanzierung.api.europace.de/kundenangaben",
+						"url": "https://baufinanzierung.api.europace.de/kundenangaben/body-validation",
 						"description": "Kundenangaben werden empfangen und validiert. Es wird jedoch KEIN Vorgang in BaufiSmart erzeugt. Der Scope 'baufinanzierung:echtgeschaeft' wird benötigt, wenn der Datenkontext 'ECHT_GESCHAEFT' gewählt wird."
 					},
 					"response": []


### PR DESCRIPTION
Dieser PR korrigiert die URL zum Validieren von Kundenangaben.