### PR TITLE
DUCK-2154 on upload a file the categorization can be started immediately.

### DIFF
--- a/EUROPACE API Calls.postman_collection.json
+++ b/EUROPACE API Calls.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "e4f086db-cbe3-4763-aec5-ea017c180d49",
+		"_postman_id": "7821e0a1-80e1-4dd4-acb3-77fe10e7d1a4",
 		"name": "EUROPACE API Calls",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
 	},
@@ -1354,7 +1354,7 @@
 								],
 								"body": {
 									"mode": "raw",
-									"raw": "{\n\t\"vorgangsNummer\": \"{{vorgangsNummer}}\",\n\t\"url\": \"Url-zum-Dokument\",\n\t\"anzeigename\": \"PostmanUploaded\"\n}"
+									"raw": "{\n\t\"vorgangsNummer\": \"{{vorgangsNummer}}\",\n\t\"url\": \"Url-zum-Dokument\",\n\t\"anzeigename\": \"PostmanUploaded\",\n    \"mitKategorisierung\" : true\n}"
 								},
 								"url": {
 									"raw": "https://api.europace2.de/v1/dokumente",
@@ -1367,46 +1367,6 @@
 									"path": [
 										"v1",
 										"dokumente"
-									]
-								}
-							},
-							"response": []
-						},
-						{
-							"name": "starte Kategorisierung",
-							"request": {
-								"method": "POST",
-								"header": [
-									{
-										"key": "Accept",
-										"value": "application/json"
-									},
-									{
-										"key": "X-TraceId",
-										"value": "{{traceId}}"
-									},
-									{
-										"key": "Content-Type",
-										"value": "application/json"
-									}
-								],
-								"body": {
-									"mode": "raw",
-									"raw": "{}"
-								},
-								"url": {
-									"raw": "https://api.europace2.de/v1/dokumente/{{dokId}}/kategorisierung",
-									"protocol": "https",
-									"host": [
-										"api",
-										"europace2",
-										"de"
-									],
-									"path": [
-										"v1",
-										"dokumente",
-										"{{dokId}}",
-										"kategorisierung"
 									]
 								}
 							},


### PR DESCRIPTION
## motivation
endpoint to start categorization is already deprecated for a while.
Prefered way is to start categorization directly on upload.

## change
removed rest call to start categorization
added flag to upload information so categorization will started directly